### PR TITLE
Add downloader for uncompressed CSV files

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec node utils/download_data.js

--- a/bin/start
+++ b/bin/start
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec node --max_old_space_size=4096 import.js $@

--- a/package.json
+++ b/package.json
@@ -36,14 +36,15 @@
     "temp": "^0.8.3"
   },
   "scripts": {
-    "import": "npm start",
+    "import": "./bin/start",
     "parallel": "./bin/parallel",
     "test": "NODE_ENV=test npm run units",
     "units": "node test/test.js | tap-spec",
+    "download": "./bin/download",
     "lint": "jshint .",
     "validate": "npm ls",
     "travis": "npm ls",
-    "start": "node --max_old_space_size=4096 import.js"
+    "start": "./bin/start"
   },
   "repository": {
     "type": "git",

--- a/schema.js
+++ b/schema.js
@@ -12,6 +12,7 @@ module.exports = Joi.object().keys({
     csv: Joi.object().keys({
       files: Joi.array().items(Joi.string()),
       datapath: Joi.string(),
+      download: Joi.array(),
       deduplicate: Joi.boolean(),
       adminLookup: Joi.boolean()
     }).requiredKeys('datapath').unknown(false)

--- a/utils/download_data.js
+++ b/utils/download_data.js
@@ -1,0 +1,1 @@
+process.exit(0);

--- a/utils/download_data.js
+++ b/utils/download_data.js
@@ -1,1 +1,43 @@
-process.exit(0);
+const child_process = require('child_process');
+const url = require('url');
+const path = require('path');
+const async = require('async');
+const fs = require('fs-extra');
+const tmp = require('tmp');
+const logger = require('pelias-logger').get('csv-download');
+const config = require('pelias-config').generate();
+
+function getFilenameFromURL(download_url) {
+  const parsed_url = url.parse(download_url);
+  return path.basename(parsed_url.pathname);
+}
+
+// handle files that do not appear to be compressed in any way
+function downloadStandard(targetDir, download_url, callback) {
+  const filename = getFilenameFromURL(download_url);
+  const download_path = path.join(targetDir, filename);
+
+  logger.info(`Downloading ${download_url} to ${download_path}`);
+
+  const cmd =`curl -L -X GET -o ${download_path} ${download_url}`;
+  logger.debug(cmd);
+  child_process.exec(cmd, callback);
+}
+
+const targetDir = config.get('imports.csv.datapath');
+const files = config.get('imports.csv.download');
+
+if (!files) {
+  logger.warn('No files to download, quitting');
+}
+
+if (!targetDir) {
+  logger.warn('Datapath for saving files not configured, quitting');
+}
+
+logger.info(`Attempting to download selected data files: ${files}`);
+
+
+async.eachLimit(files, 5, downloadStandard.bind(null, targetDir), function() {
+  logger.info('all done');
+});


### PR DESCRIPTION
This PR adds what should be a flexible but robust downloader, currently supporting any uncompressed CSV file, but build to be able to be extended in the future to transparently handle `zip`, `gzip`, `and bzip2` files.