### PR TITLE
Add support for `cross_street` address field

### DIFF
--- a/lib/streams/documentStream.js
+++ b/lib/streams/documentStream.js
@@ -92,6 +92,11 @@ function processRecord(record, next_uid, stats) {
       pelias_document.setAddress('street', street);
     }
 
+    const cross_street = getCrossStreet(record)
+    if (cross_street) {
+      pelias_document.setAddress('cross_street', cross_street);
+    }
+
     const housenumber = getHousenumber(record);
     if (housenumber) {
       pelias_document.setAddress('number', housenumber);


### PR DESCRIPTION
This uses the support for `cross_street` added in https://github.com/pelias/model/pull/111 and https://github.com/pelias/schema/pull/346