### PR TITLE
fix(schema): Remove required keys

### DIFF
--- a/import.js
+++ b/import.js
@@ -26,7 +26,7 @@ function startTiming() {
 var args = parameters.interpretUserArgs( process.argv.slice( 2 ) );
 
 if( 'exitCode' in args ){
-  ((args.exitCode > 0) ? console.error : console.info)( args.errMessage );
+  ((args.exitCode > 0) ? logger.error : logger.info)( args.errMessage );
   process.exit( args.exitCode );
 } else {
   startTiming();

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -62,11 +62,13 @@ function interpretUserArgs( argv ){
     'parallel-count': argv['parallel-count'],
     'parallel-id': argv['parallel-id']
   };
-  if (peliasConfig.imports.csv) {
+  if (peliasConfig.get('imports.csv.datapath')) {
     opts.dirPath = peliasConfig.imports.csv.datapath;
   } else {
-    //pick a somewhat reasonable data path
-    opts.dirPath = '/mnt/data/csv'
+    return {
+      errMessage: 'No datapath configured, nothing to do',
+      exitCode: 0
+    };
   }
 
   opts.dirPath = path.normalize(opts.dirPath);

--- a/schema.js
+++ b/schema.js
@@ -15,6 +15,6 @@ module.exports = Joi.object().keys({
       download: Joi.array(),
       deduplicate: Joi.boolean(),
       adminLookup: Joi.boolean()
-    }).requiredKeys('datapath').unknown(false)
+    })
   }).requiredKeys('csv').unknown(true)
 }).requiredKeys('imports').unknown(true);

--- a/test/schema.js
+++ b/test/schema.js
@@ -59,14 +59,14 @@ tape('non-object imports.csv should throw error', function(test) {
 
 });
 
-tape( 'missing datapath should throw error', function(test) {
+tape( 'missing datapath should not throw error', function(test) {
   const config = {
     imports: {
       csv: {}
     }
   };
 
-  test.throws(validate.bind(null, config), /"datapath" is required/);
+  test.doesNotThrow(validate.bind(null, config), 'datapath is not required');
   test.end();
 
 });


### PR DESCRIPTION
The CSV importer is designed to be optional, and thus all config options should be optional as well.