### PR TITLE
feat(import): Add admin lookup

### DIFF
--- a/lib/importPipeline.js
+++ b/lib/importPipeline.js
@@ -3,6 +3,7 @@ const recordStream = require('./streams/recordStream');
 const model = require('pelias-model');
 const peliasDbclient = require('pelias-dbclient');
 const blacklistStream = require('pelias-blacklist-stream');
+const adminLookup = require('pelias-wof-admin-lookup');
 
 function createFullImportPipeline( files, dirPath, finalStream ){
   logger.info( 'Importing %s files.', files.length );
@@ -11,6 +12,7 @@ function createFullImportPipeline( files, dirPath, finalStream ){
 
   recordStream.create(files, dirPath)
     .pipe(blacklistStream())
+    .pipe(adminLookup.create())
     .pipe(model.createDocumentMapperStream())
     .pipe(finalStream);
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "pelias-dbclient": "^2.4.0",
     "pelias-logger": "^1.3.0",
     "pelias-model": "^5.3.2",
+    "pelias-wof-admin-lookup": "^5.1.1",
     "through2": "^3.0.0",
     "through2-filter": "^3.0.0",
     "through2-map": "^3.0.0",


### PR DESCRIPTION
Admin lookup support via [wof-admin-lookup](https://github.com/pelias/wof-admin-lookup) was omitted in the initial port of this project from the OpenAddresses importer.

Unlike the OpenAddresses importer, which added extra adminLookup configuration to disable lookups against some WOF layers (such as `marinelayer`, `ocean`, etc), this importer uses all layers to support any custom data (which may or may not be land based).