### PR TITLE
chore(comments): Remove out of date references to OpenAddresses

### DIFF
--- a/import.js
+++ b/import.js
@@ -1,9 +1,3 @@
-/**
- * @file Entry-point script for the OpenAddresses import pipeline.
- */
-
-'use strict';
-
 var peliasConfig = require( 'pelias-config' ).generate(require('./schema'));
 
 var logger = require( 'pelias-logger' ).get( 'csv-importer' );

--- a/lib/parameters.js
+++ b/lib/parameters.js
@@ -12,34 +12,12 @@ var peliasConfig = require( 'pelias-config' ).generate();
  * Interprets the command-line arguments passed to the script.
  *
  * @param {array} argv Should be `process.argv.slice( 2 )`.
- * @return {object} If arguments were succesfully parsed, an object that can be
- *    used to call `importOpenAddressesDir`:
- *
- *      {
- *        dirPath: <string>,
- *        adminValues: <boolean>,
- *        deduplicate: <boolean>,
- *      }
- *
- *    Otherwise, an error object.
- *
- *      {
- *        exitCode: <number>,
- *        errMessage: <string>
- *      }
+ * @return {object} If arguments were succesfully parsed, an object that contains
+ * all parsed and valid arguments
  */
 function interpretUserArgs( argv ){
   var usageMessage = [
-    'A tool for importing OpenAddresses data into Pelias. Usage:',
-    '',
-    '\tnode import.js --help | [--deduplicate] [--admin-values] [OPENADDRESSES_DIR]',
-    '',
-    '',
-    '\t--help: Print this help message.',
-    '',
-    '\tOPENADDRESSES_DIR: A directory containing OpenAddresses CSV files.',
-    '\t\tIf none is specified, the path from your PELIAS_CONFIG\'s',
-    '\t\t`imports.openaddresses.datapath` will be used.',
+    'A tool for importing custom data into Pelias.'
   ].join( '\n' );
 
   argv = minimist(argv, {});

--- a/lib/streams/recordStream.js
+++ b/lib/streams/recordStream.js
@@ -10,7 +10,7 @@ var DocumentStream = require('./documentStream');
 
 /*
  * Construct a suitable id prefix for a CSV file given
- * its full filename and the base directory of all OA CSV files.
+ * its full filename and the base data directory.
  */
 function getIdPrefix(filename, dirPath) {
   if (filename && dirPath) {
@@ -28,11 +28,11 @@ function getIdPrefix(filename, dirPath) {
 }
 
 /**
- * Create a stream of Documents from an OpenAddresses file.
+ * Create a stream of Documents from a CSV file.
  *
- * @param {string} filePath The path of an OpenAddresses CSV file.
+ * @param {string} filePath The path of a CSV file.
  * @return {stream.Readable} A stream of `Document` objects, one
- *    for every valid record inside the OA file.
+ *    for every valid record inside the file.
  */
 function createRecordStream( filePath, dirPath ){
   /**

--- a/test/streams/recordStream.js
+++ b/test/streams/recordStream.js
@@ -111,7 +111,7 @@ tape(
   }
 );
 
-tape( 'getIdPrefix returns prefix based on OA directory structure', function( test ) {
+tape( 'getIdPrefix returns prefix based on irectory structure', function( test ) {
   var filename = '/base/path/us/ca/san_francisco.csv';
   var basePath = '/base/path';
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,9 +1,3 @@
-/**
- * @file The main entry point for the OpenAddresses importer's unit-tests.
- */
-
-'use strict';
-
 require( './schema' );
 require( './import');
 require( './parameters' );


### PR DESCRIPTION
This cleans up the last bits of code remaining from converting the OA importer to the CSV importer.

Fixes https://github.com/pelias/csv-importer/issues/17