### PR TITLE
    feat(logger): Use dbclient name functionality

### DIFF
--- a/import.js
+++ b/import.js
@@ -27,5 +27,12 @@ if( 'exitCode' in args ){
 
   var files = parameters.getFileList(peliasConfig, args);
 
-  importPipeline.create( files, args.dirPath );
+  const importer_id = args['parallel-id'];
+  let importer_name = 'csv';
+
+  if (importer_id !== undefined) {
+    importer_name = `csv-${importer_id}`;
+  }
+
+  importPipeline.create( files, args.dirPath, importer_name);
 }

--- a/lib/importPipeline.js
+++ b/lib/importPipeline.js
@@ -5,14 +5,14 @@ const peliasDbclient = require('pelias-dbclient');
 const blacklistStream = require('pelias-blacklist-stream');
 const adminLookup = require('pelias-wof-admin-lookup');
 
-function createFullImportPipeline( files, dirPath ){
+function createFullImportPipeline( files, dirPath, importerName ){
   logger.info( 'Importing %s files.', files.length );
 
   recordStream.create(files, dirPath)
     .pipe(blacklistStream())
     .pipe(adminLookup.create())
     .pipe(model.createDocumentMapperStream())
-    .pipe(peliasDbclient());
+    .pipe(peliasDbclient({name: importerName}));
 }
 
 module.exports = {

--- a/lib/importPipeline.js
+++ b/lib/importPipeline.js
@@ -5,16 +5,14 @@ const peliasDbclient = require('pelias-dbclient');
 const blacklistStream = require('pelias-blacklist-stream');
 const adminLookup = require('pelias-wof-admin-lookup');
 
-function createFullImportPipeline( files, dirPath, finalStream ){
+function createFullImportPipeline( files, dirPath ){
   logger.info( 'Importing %s files.', files.length );
-
-  finalStream = finalStream || peliasDbclient();
 
   recordStream.create(files, dirPath)
     .pipe(blacklistStream())
     .pipe(adminLookup.create())
     .pipe(model.createDocumentMapperStream())
-    .pipe(finalStream);
+    .pipe(peliasDbclient());
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "minimist": "1.2.0",
     "pelias-blacklist-stream": "^1.0.0",
     "pelias-config": "^3.3.0",
-    "pelias-dbclient": "^2.4.0",
+    "pelias-dbclient": "^2.8.0",
     "pelias-logger": "^1.3.0",
     "pelias-model": "^5.8.0",
     "pelias-wof-admin-lookup": "^5.1.1",


### PR DESCRIPTION
This allows distinguishing which logger output lines correspond to which importer during an import.

Unlike other importers, this PR is slightly more complicated as we have to support unique names for each of what might be several parallel sub-importers.

Dependency injection for `dbclient` was removed to facilitate this.

Connects https://github.com/pelias/dbclient/issues/101
