### PR TITLE
fix(source): Support case insensitive source field

### DIFF
--- a/lib/streams/documentStream.js
+++ b/lib/streams/documentStream.js
@@ -20,7 +20,7 @@ function getLayer(record) {
 }
 
 function getSource(record) {
-  return record.source || 'csv';
+  return getCaseInsensitive('source', record) || 'csv';
 }
 
 function getHousenumber(record) {

--- a/test/streams/documentStream.js
+++ b/test/streams/documentStream.js
@@ -175,24 +175,41 @@ tape('documentStream uses name value if present (over NAME)', function(test) {
   });
 });
 
-tape('documentStream uses layer value if present (over LAYER, layer_id, and LAYER_ID)', function(test) {
+tape('documentStream uses source value if present (over SOURCE)', function(test) {
   const input = {
     NUMBER: '5',
     STREET: '101st Avenue',
     LAT: 5,
     LON: 6,
-    HASH: 'abcd',
-    layer: 'desired-layer',
-    LAYER: 'wrong',
-    layer_id: 'wrong2',
-    LAYER_ID: 'wrong3'
+    source: 'desired-source',
+    SOURCE: 'wrong'
   };
 
   const stats = { badRecordCount: 0 };
   const documentStream = DocumentStream.create('prefix', stats);
 
   test_stream([input], documentStream, function(err, actual) {
-    test.equal(actual[0].getLayer(), 'desired-layer', 'layer set correctly');
+    test.equal(actual[0].getSource(), 'desired-source', 'source set correctly');
+    test.equal(actual.length, 1, 'the document should be pushed' );
+    test.equal(stats.badRecordCount, 0, 'bad record count unchanged');
+    test.end();
+  });
+});
+
+tape('documentStream uses SOURCE value if present (and source not present)', function(test) {
+  const input = {
+    NUMBER: '5',
+    STREET: '101st Avenue',
+    LAT: 5,
+    LON: 6,
+    SOURCE: 'desired-source'
+  };
+
+  const stats = { badRecordCount: 0 };
+  const documentStream = DocumentStream.create('prefix', stats);
+
+  test_stream([input], documentStream, function(err, actual) {
+    test.equal(actual[0].getSource(), 'desired-source', 'source set correctly');
     test.equal(actual.length, 1, 'the document should be pushed' );
     test.equal(stats.badRecordCount, 0, 'bad record count unchanged');
     test.end();


### PR DESCRIPTION
After this, I believe all fields are _actually_ case insensitive, which the README has promised for some time.