### PR TITLE
feat(deps): Use carat range for combined-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "import.js",
   "dependencies": {
     "async": "^2.5.0",
-    "combined-stream": "1.0.7",
+    "combined-stream": "^1.0.7",
     "csv-parse": "^4.0.1",
     "fs-extra": "^8.0.0",
     "glob": "^7.0.0",


### PR DESCRIPTION
As mentioned in https://github.com/pelias/openaddresses/pull/343, we were a bit nervous about a behavior change introduced in combined-stream 1.0.7.

However, as discovered in https://github.com/felixge/node-combined-stream/issues/40 it's a bugfix that makes previously unrecommended use of the library finally break.

The code in this repository is already using the library in the recommended way, and isn't affected, so we might as well stay with the latest version.

Closes https://github.com/pelias/csv-importer/pull/32