### PR TITLE
Supports for categories, multi-lang columns and aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,34 @@ cause all but the most recent record to be overwritten.
 
 If an ID is not specified for a row in a CSV, the row number will be used.
 
+## Names in multiple Languages
+
+Multiple names in different languages can be assigned by using the `name_$lang` fields, where $lang is an [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) language code.
+
+For example, to create a record for London in English and French, use the following CSV:
+
+id | name | name_fr | source | layer | lat | lon |
+-- | ---- | ------- | ------ | ----- | --- | --- |
+1 | London | Londres | custom | locality | 5 | 6 |
+
+## Multiple alias names
+
+A record can have multiple aliases, or alternative names, specified as an array using the `name_json` field.
+
+The following CSV will create a record for [John F Kennedy International Airport](https://en.wikipedia.org/wiki/John_F._Kennedy_International_Airport), with common aliases including `JFK` and `JFK airport`.
+
+id | name | name_json | source | layer | lat | lon |
+-- | ---- | ------- | ------ | ----- | --- | --- |
+1 | John F Kennedy International Airport | "[""JFK"", ""JFK Airport""]" | custom | venue | 40.639722 | -73.778889
+
+The contents of the `name_json` field must be a JSON array. As a reminder, in CSV files, records that contain commas must be quoted using double quotes, and records with a double quote in the value itself must be double-double-quoted, as shown above.
+
+Aliases and languages can _both_ be specified. For example, the `name_json_es` field allows setting multiple aliases in Spanish.
+
+## Categories
+
+Category values can be added to a record. For a single category, use the `category` field. For multiple categories, use `category_json`, with the same formatting as for alias names.
+
 ## Custom data
 
 Arbitrary custom data that does not fit into the standard Pelias schema can be stored for later retrieval under the `addendum` property.

--- a/lib/streams/documentStream.js
+++ b/lib/streams/documentStream.js
@@ -3,6 +3,7 @@
 const through = require( 'through2' );
 
 const peliasModel = require( 'pelias-model' );
+const NAME_REGEX = /^name(_json)?_([a-z]{2})$/i;
 
 function getPostalCode(record) {
   return getCaseInsensitive('zipcode', record)
@@ -10,12 +11,24 @@ function getPostalCode(record) {
     || getCaseInsensitive('postalcode', record);
 }
 
-function getName(record) {
-  const name = getCaseInsensitive('name', record);
-  if (name && typeof name === 'string') {
-    return name.trim();
+function _getByStringOrJson(prefix) {
+  return (record, suffix = '') => {
+    let result = []
+    const value = getCaseInsensitive(`${prefix}${suffix}`, record);
+    if (value && typeof value === 'string') {
+      result.push(value.trim());
+    }
+    const value_json = getCaseInsensitiveAsJSON(`${prefix}_json${suffix}`, record);
+    if (value_json && value_json instanceof Array) {
+      result = result.concat(value_json);
+    }
+
+    return result;
   }
 }
+
+const getNames = _getByStringOrJson('name');
+const getCategories = _getByStringOrJson('category');
 
 function getLayer(record) {
   return getCaseInsensitive('layer', record) || getCaseInsensitive('layer_id', record) || 'venue';
@@ -47,6 +60,14 @@ function getCaseInsensitive(field, record) {
   return record[lower] || record[upper];
 }
 
+function getCaseInsensitiveAsJSON(field, record) {
+  const value = getCaseInsensitive(field, record);
+  if (value && typeof value === 'string') {
+    return JSON.parse(value);
+  }
+  return value;
+}
+
 function getPrefixedFields(prefix, record) {
   let result = {};
 
@@ -58,6 +79,29 @@ function getPrefixedFields(prefix, record) {
   });
 
   return result;
+}
+
+function getMultiLangNames(record) {
+  const result = { default: record };
+
+  Object.keys(record)
+    .filter(field => /^name_/i.test(field))
+    .forEach(field => {
+      const value = NAME_REGEX.exec(field)
+      const isJson = value && value[1];
+      let lang = value && value[2];
+      if (lang && typeof lang === 'string') {
+        lang = lang.toLowerCase();
+        result[lang] = result[lang] || {};
+        if (isJson && typeof isJson === 'string') {
+          result[lang][`name_json_${lang}`] = record[field];
+        } else {
+          result[lang][`name_${lang}`] = record[field];
+        }
+      }
+    })
+
+  return Object.entries(result);
 }
 
 function getCentroid(record) {
@@ -79,9 +123,15 @@ function processRecord(record, next_uid, stats) {
 
     const pelias_document = new peliasModel.Document( source, layer, model_id );
 
-    if (getName(record)) {
-      pelias_document.setName('default', getName(record));
-    }
+    getMultiLangNames(record).forEach(([lang, value]) => {
+      const names = getNames(value, lang === 'default' ? '' : `_${lang}`);
+      if (names && names.length > 0) {
+        pelias_document.setName(lang, names[0]);
+        for (let i = 1; i < names.length; i++) {
+          pelias_document.setNameAlias(lang, names[i]);
+        }
+      }
+    })
 
     const centroid = getCentroid(record);
     if (centroid) {
@@ -115,6 +165,9 @@ function processRecord(record, next_uid, stats) {
     Object.keys(addendumFields).forEach(function(namespace) {
       pelias_document.setAddendum(namespace, JSON.parse(addendumFields[namespace]));
     });
+
+    getCategories(record)
+      .forEach(category => pelias_document.addCategory(category));
 
     return pelias_document;
   } catch ( ex ){

--- a/test/parameters.js
+++ b/test/parameters.js
@@ -72,6 +72,7 @@ tape('interpretUserArgs returns dir from pelias config if set', function(test) {
     var result = parameters.interpretUserArgs(input);
 
     test.equal(result.dirPath, temporary_dir, 'path should be equal to path from config');
+    temp.cleanupSync();
     test.end();
   });
 });
@@ -100,6 +101,7 @@ tape('interpretUserArgs returns normalized path from config', function(test) {
 
     var expected_dir = path.normalize(input_dir);
     test.equal(result.dirPath, expected_dir, 'path should be equal to path from config');
+    temp.cleanupSync();
     test.end();
   });
 });
@@ -135,6 +137,7 @@ tape('getFileList returns all .csv path names when config has empty files list',
     test.ok(actual.find((f) => f === path.join(temp_dir, 'dirA', 'fileA.csv')));
     test.ok(actual.find((f) => f === path.join(temp_dir, 'dirB', 'fileB.csv')));
     test.ok(actual.find((f) => f === path.join(temp_dir, 'fileC.csv')));
+    temp.cleanupSync();
     test.end();
 
   });
@@ -170,6 +173,7 @@ tape('getFileList returns all .csv path names when config doesn\'t have files pr
     test.ok(actual.find((f) => f === path.join(temp_dir, 'dirA', 'fileA.csv')));
     test.ok(actual.find((f) => f === path.join(temp_dir, 'dirB', 'fileB.csv')));
     test.ok(actual.find((f) => f === path.join(temp_dir, 'fileC.csv')));
+    temp.cleanupSync();
     test.end();
 
   });
@@ -193,6 +197,7 @@ tape('getFileList returns fully qualified path names when config has a files lis
     var actual = parameters_default.getFileList(peliasConfig, args);
 
     test.deepEqual(actual, expected, 'file names should be equal');
+    temp.cleanupSync();
     test.end();
   });
 });
@@ -264,6 +269,7 @@ tape('getFileList handles parallel builds', function(test) {
       var actual = parameters_default.getFileList(peliasConfig, args);
 
       t.deepEqual(actual, expected, 'file list is empty');
+      temp.cleanupSync();
       t.end();
     });
     test.end();

--- a/test/streams/documentStream.js
+++ b/test/streams/documentStream.js
@@ -279,3 +279,49 @@ tape('documentStream parses JSON from addendum_json_* field', function(test) {
     test.end();
   });
 });
+
+tape('documentStream parses JSON from name_json_* field', function(test) {
+  const input = {
+    LAT: 5,
+    LON: 6,
+    HASH: 'abcd',
+    layer_id: 'desired-layer',
+    name_json_fr: '["bar", "baz"]',
+    name_json: '["foo"]'
+  };
+
+  const stats = { badRecordCount: 0 };
+  const documentStream = DocumentStream.create('prefix', stats);
+
+  test_stream([input], documentStream, function(err, actual) {
+    test.equal(actual.length, 1, 'the document should be pushed' );
+    test.deepEquals(actual[0].getName('default'), 'foo', 'default name is added to record');
+    test.deepEquals(actual[0].getName('fr'), 'bar', 'fr name is added to record');
+    test.deepEquals(actual[0].getNameAliases('fr'), ['baz'], 'fr name is added to record');
+    test.equal(stats.badRecordCount, 0, 'bad record count unchanged');
+    test.end();
+  });
+});
+
+tape('documentStream parses JSON from category_json field', function(test) {
+  const input = {
+    LAT: 5,
+    LON: 6,
+    HASH: 'abcd',
+    layer_id: 'desired-layer',
+    name: 'foo',
+    category: 'bar',
+    category_json: '["baz"]'
+  };
+
+  const stats = { badRecordCount: 0 };
+  const documentStream = DocumentStream.create('prefix', stats);
+
+  test_stream([input], documentStream, function(err, actual) {
+    test.equal(actual.length, 1, 'the document should be pushed' );
+    test.deepEquals(actual[0].getName('default'), 'foo', 'default name is added to record');
+    test.deepEquals(actual[0].category, ['bar', 'baz'], 'default name is added to record');
+    test.equal(stats.badRecordCount, 0, 'bad record count unchanged');
+    test.end();
+  });
+});


### PR DESCRIPTION
# Background

The current CSV importer is very basic. We can do something much more interesting here, specially when we have custom data with many information.
OSM is a good example, when can have a tons of information like categories and multi-lang. This should be a good addition for this importer.

# What's new ?

I added some new columns to enrich the data. Columns are:

- name_{lang}: Should be a ISO 639-1 language code, like we do with OSM
- name_json: Should be a JSON Array for the default name, this is cool for name aliases
- name_json_{lang}: Sould be a JSON Array for the specified lang
- category: A simple category to add for this entry
- category_json: A JSON Array to add many categories for an entry

# How it works ?

Use theses new columns in your CSV and voilà.