### PR TITLE
chore(deps): Use carat ranges for dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "fs-extra": "^8.0.0",
     "glob": "^7.0.0",
     "lodash": "^4.16.0",
-    "minimist": "1.2.0",
+    "minimist": "^1.2.0",
     "pelias-blacklist-stream": "^1.0.0",
     "pelias-config": "^4.8.0",
     "pelias-dbclient": "^2.13.0",
@@ -25,14 +25,14 @@
     "through2-filter": "^3.0.0",
     "through2-map": "^3.0.0",
     "through2-sink": "^1.0.0",
-    "tmp": "0.1.0"
+    "tmp": "^0.1.0"
   },
   "devDependencies": {
     "deep-diff": "^1.0.2",
     "stream-mock": "^2.0.3",
     "jshint": "^2.9.4",
     "proxyquire": "^2.1.0",
-    "tap-spec": "5.0.0",
+    "tap-spec": "^5.0.0",
     "tape": "^4.5.0",
     "temp": "^0.9.0"
   },


### PR DESCRIPTION
Looks like a few dependencies were missing their carat range specifiers.

We decided on this all the way back in https://github.com/pelias/pelias/issues/366

Closes https://github.com/pelias/csv-importer/pull/57