### PR TITLE
Explicitly bump to pelias-wof-admin-lookup v7.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "pelias-dbclient": "^2.13.0",
     "pelias-logger": "^1.3.0",
     "pelias-model": "^7.1.0",
-    "pelias-wof-admin-lookup": "^7.0.0",
+    "pelias-wof-admin-lookup": "^7.1.0",
     "through2": "^3.0.0",
     "through2-filter": "^3.0.0",
     "through2-map": "^3.0.0",


### PR DESCRIPTION
We want to ensure the new postal cities override logic is included: https://github.com/pelias/wof-admin-lookup/pull/296.