### PR TITLE
fix(postalcode): Support postalcode as field name

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Valid column names for street are: `street`
 
 Valid column names for housenumber are: `housenumber`, `number`
 
-Valid column names for postalcode are: `postalcode`, `zipcode`
+Valid column names for postalcode are: `postalcode`, `postcode`, `zipcode`
 
 Valid column names for intersections are: `cross_street` (note: `street` is also required!)
 

--- a/lib/streams/documentStream.js
+++ b/lib/streams/documentStream.js
@@ -5,7 +5,9 @@ const through = require( 'through2' );
 const peliasModel = require( 'pelias-model' );
 
 function getPostalCode(record) {
-  return getCaseInsensitive('zipcode', record) || getCaseInsensitive('postcode', record);
+  return getCaseInsensitive('zipcode', record)
+    || getCaseInsensitive('postcode', record)
+    || getCaseInsensitive('postalcode', record);
 }
 
 function getName(record) {

--- a/test/streams/documentStream.js
+++ b/test/streams/documentStream.js
@@ -94,6 +94,25 @@ tape( 'documentStream accepts zipcode instead of POSTCODE', function(test) {
   });
 });
 
+tape( 'documentStream accepts postalcode instead of POSTCODE', function(test) {
+  const input = {
+    NUMBER: '5',
+    STREET: '101st Avenue',
+    LAT: 5,
+    LON: 6,
+    postalcode: '10010'
+  };
+  const stats = { badRecordCount: 0 };
+  const documentStream = DocumentStream.create('prefix', stats);
+
+  test_stream([input], documentStream, function(err, actual) {
+    test.equal(actual.length, 1, 'the document should be pushed' );
+    test.equal(stats.badRecordCount, 0, 'bad record count unchanged');
+    test.equal(actual[0].getAddress('zip'), '10010');
+    test.end();
+  });
+});
+
 tape('documentStream uses id value over hash if present', function(test) {
   const input = {
     NUMBER: '5',


### PR DESCRIPTION
The readme suggested that `postalcode` and `zipcode` were the allowed names of fields for postal code information.

In fact, `postcode` was allowed, but _not_ `postalcode`. Now both are supported.