### PR TITLE
feat(deps): Update config to enable postal cities by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lodash": "^4.16.0",
     "minimist": "^1.2.0",
     "pelias-blacklist-stream": "^1.0.0",
-    "pelias-config": "^4.8.0",
+    "pelias-config": "^4.12.0",
     "pelias-dbclient": "^2.13.0",
     "pelias-logger": "^1.3.0",
     "pelias-model": "^7.1.0",


### PR DESCRIPTION
We have now enabled postal cities by default, this updates the pelias/config to require the latest version with that change

Connects https://github.com/pelias/pelias/issues/396
Connects https://github.com/pelias/config/pull/129