### PR TITLE
Remove deprecated `sudo: false` TravisCI config flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: node_js
 notifications:
   email: false


### PR DESCRIPTION
This flag is no longer needed and causes an alarming yellow circle to appear in the Travis UI for the build config validation :)