### PR TITLE
feat(parallel): Improve parallel import

### DIFF
--- a/bin/parallel
+++ b/bin/parallel
@@ -7,15 +7,18 @@ count=$1
 shift
 
 # only do anything if count is a valid integer >= 1
-if [[ $count -ge 1 ]]; then
-	echo "starting $count parallel builds"
+if [[ $count -gt 1 ]]; then
+	echo "CSV importer: starting $count parallel builds"
 
 	# spawn $count parallel builds, passing correct params and all arguments
 	for i in `seq 0 $(($count-1))`; do
-		cmd="npm start -- --parallel-count $count --parallel-id $i $@ "
+		cmd="./bin/start --parallel-count $count --parallel-id $i $@"
 		$cmd &
 	done
 
 	# don't let this script finish until all parallel builds have finished
 	wait
+else
+	# invalid count value, run normal build
+	exec ./bin/start $@
 fi


### PR DESCRIPTION
This improves the parallel import entry point, allowing it to be used for general purposes as the OA parallel import script is, since https://github.com/pelias/openaddresses/pull/410.

Now we can use `./bin/parallel` always, and handle parallelization in places like pelias/docker