### PR TITLE
feat(json): Allow empty addendum json

### DIFF
--- a/lib/streams/documentStream.js
+++ b/lib/streams/documentStream.js
@@ -177,7 +177,9 @@ function processRecord(record, next_uid, stats) {
 
     const addendumFields = getPrefixedFields('addendum_json_', record);
     Object.keys(addendumFields).forEach(function(namespace) {
-      pelias_document.setAddendum(namespace, JSON.parse(addendumFields[namespace]));
+      if (addendumFields[namespace]) {
+        pelias_document.setAddendum(namespace, JSON.parse(addendumFields[namespace]));
+      }
     });
 
     getCategories(record)

--- a/test/streams/documentStream.js
+++ b/test/streams/documentStream.js
@@ -280,6 +280,77 @@ tape('documentStream parses JSON from addendum_json_* field', function(test) {
   });
 });
 
+tape('documentStream parses empty JSON from addendum_json_* field', function(test) {
+  const input = {
+    NUMBER: '5',
+    STREET: '101st Avenue',
+    LAT: 5,
+    LON: 6,
+    HASH: 'abcd',
+    layer_id: 'desired-layer',
+    addendum_json_custom_field: ''
+  };
+
+  const stats = { badRecordCount: 0 };
+  const documentStream = DocumentStream.create('prefix', stats);
+
+
+  test_stream([input], documentStream, function(err, actual) {
+    console.log(JSON.stringify(actual, null, 2));
+    test.deepEquals(actual[0].getAddendum('custom_field'), undefined, 'undefined custom data is added to record');
+    test.equal(actual.length, 1, 'the document should be pushed' );
+    test.equal(stats.badRecordCount, 0, 'bad record count unchanged');
+    test.end();
+  });
+});
+
+
+tape('documentStream parses undefined JSON from addendum_json_* field', function(test) {
+  const input = {
+    NUMBER: '5',
+    STREET: '101st Avenue',
+    LAT: 5,
+    LON: 6,
+    HASH: 'abcd',
+    layer_id: 'desired-layer',
+    addendum_json_custom_field: undefined
+  };
+
+  const stats = { badRecordCount: 0 };
+  const documentStream = DocumentStream.create('prefix', stats);
+
+
+  test_stream([input], documentStream, function(err, actual) {
+    console.log(JSON.stringify(actual, null, 2));
+    test.deepEquals(actual[0].getAddendum('custom_field'), undefined, 'undefined custom data is added to record');
+    test.equal(actual.length, 1, 'the document should be pushed' );
+    test.equal(stats.badRecordCount, 0, 'bad record count unchanged');
+    test.end();
+  });
+});
+
+tape('documentStream does not parse corrupt JSON from addendum_json_* field', function(test) {
+  const input = {
+    NUMBER: '5',
+    STREET: '101st Avenue',
+    LAT: 5,
+    LON: 6,
+    HASH: 'abcd',
+    layer_id: 'desired-layer',
+    addendum_json_custom_field: '{ "foo": "bar'
+  };
+
+  const stats = { badRecordCount: 0 };
+  const documentStream = DocumentStream.create('prefix', stats);
+
+  test_stream([input], documentStream, function(err, actual) {
+    // console.log(JSON.stringify(actual, null, 2));
+    test.equal(actual.length, 0, 'the document should not be pushed' );
+    test.equal(stats.badRecordCount, 1, 'bad record count 1');
+    test.end();
+  });
+});
+
 tape('documentStream parses JSON from name_json_* field', function(test) {
   const input = {
     LAT: 5,


### PR DESCRIPTION
I had a csv import that was silently failing because my addendum_json_XXX field was empty in some rows.

This change allows for empty values in addenum_json_XXX fields and adds a lot of tests for both that field and other json fields in csv import

In a separate change, I will attempt to print out badRecordCount somewhere, and in another I will propose we log failed rows to stderr