### PR TITLE
feat(logging): add a status message when a csv is done importing with good/bad counts

### DIFF
--- a/lib/streams/documentStream.js
+++ b/lib/streams/documentStream.js
@@ -187,6 +187,7 @@ function processRecord(record, next_uid, stats) {
     getCategories(record)
       .forEach(category => pelias_document.addCategory(category));
 
+    stats.goodRecordCount++;
     return pelias_document;
   } catch ( ex ){
     logger.warn(`Record import failed on line ${next_uid} due to ${ex.message || ex}.`, record)

--- a/lib/streams/recordStream.js
+++ b/lib/streams/recordStream.js
@@ -39,7 +39,8 @@ function createRecordStream( filePath, dirPath ){
    * A stream to convert rows of a CSV to Document objects.
    */
   var stats = {
-    badRecordCount: 0
+    badRecordCount: 0,
+    goodRecordCount: 0
   };
 
   var csvParser = csvParse({
@@ -55,7 +56,10 @@ function createRecordStream( filePath, dirPath ){
 
   return fs.createReadStream( filePath )
     .pipe( csvParser )
-    .pipe( documentStream );
+    .pipe( documentStream )
+    .on('finish', () => {
+      logger.info(`Finished import from ${filePath}, goodRecordCount=${stats.goodRecordCount} badRecordCount=${stats.badRecordCount}`)
+    })
 }
 
 /*


### PR DESCRIPTION
Adds this message in stdout at the end of each csv file

`    2020-10-09T19:37:43.930Z - info: [csv-importer] Finished import from /var/folders/_d/jq4xv1d94p129cm4899l3zbc0000gn/T/csv-importer-test202099-52784-m927ct.shrvf, goodRecordCount=1 badRecordCount=0`

I beleive this will make it much easier to notice when csv files have problems