### PR TITLE
add a warning message when a line of csv import fails

### DIFF
--- a/lib/streams/documentStream.js
+++ b/lib/streams/documentStream.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const through = require( 'through2' );
+const logger = require( 'pelias-logger' ).get( 'csv-importer' );
+
 
 const peliasModel = require( 'pelias-model' );
 const NAME_REGEX = /^name(_json)?_([a-z]{2})$/i;
@@ -185,6 +187,7 @@ function processRecord(record, next_uid, stats) {
 
     return pelias_document;
   } catch ( ex ){
+    logger.warn(`Record import failed on line ${next_uid} due to ${ex.message || ex}.`, record)
     stats.badRecordCount++;
   }
 }


### PR DESCRIPTION
I had some lines in a csv import that were not importing and it was very confusing to figure out why. This adds a warning logger message for those failed records


`    2020-10-09T19:42:57.868Z - warn: [csv-importer] Record import failed on line 0 due to Invalid centroid. name=foo, LAT=7`

`    2020-10-09T19:42:57.878Z - warn: [csv-importer] Record import failed on line 0 due to Popularity must be an int, got 500a0. NUMBER=5, STREET=101st Avenue, LAT=5, LON=6, postalcode=10010, popularity=500a0`