### PR TITLE
strip byte-order-mark from CSV files

### DIFF
--- a/lib/streams/recordStream.js
+++ b/lib/streams/recordStream.js
@@ -1,12 +1,10 @@
-var fs = require( 'fs' );
-var path = require( 'path' );
-
-var csvParse = require( 'csv-parse' );
-var combinedStream = require( 'combined-stream' );
-var _ = require( 'lodash' );
-
-var logger = require( 'pelias-logger' ).get( 'csv-importer' );
-var DocumentStream = require('./documentStream');
+const _ = require('lodash');
+const fs = require('fs');
+const path = require('path');
+const csvParse = require('csv-parse').parse;
+const combinedStream = require('combined-stream');
+const logger = require('pelias-logger').get('csv-importer');
+const DocumentStream = require('./documentStream');
 
 /*
  * Construct a suitable id prefix for a CSV file given
@@ -45,6 +43,7 @@ function createRecordStream( filePath, dirPath ){
 
   var csvParser = csvParse({
     trim: true,
+    bom: true,
     skip_empty_lines: true,
     relax_column_count: true,
     relax: true,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@hapi/joi": "^16.0.0",
     "async": "^3.0.1",
     "combined-stream": "^1.0.7",
-    "csv-parse": "^4.0.1",
+    "csv-parse": "^5.0.3",
     "fs-extra": "^8.0.0",
     "glob": "^7.0.0",
     "lodash": "^4.16.0",


### PR DESCRIPTION
this PR enables the [bom: true](https://csv.js.org/parse/options/bom/) config option which strips the [Byte Order Mark](https://en.wikipedia.org/wiki/Byte_order_mark) from files (where present).

I've coupled this change with an upgrade to the `npm csv-parse` module. [changelog](https://github.com/adaltas/node-csv/blob/master/packages/csv-parse/CHANGELOG.md)

resolves https://github.com/pelias/csv-importer/issues/89