### PR TITLE
Upgrade to wof-admin-lookup 7.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "pelias-dbclient": "^2.13.0",
     "pelias-logger": "^1.3.0",
     "pelias-model": "^9.2.0",
-    "pelias-wof-admin-lookup": "^7.3.0",
+    "pelias-wof-admin-lookup": "^7.7.0",
     "through2": "^3.0.0",
     "through2-filter": "^3.0.0",
     "through2-map": "^3.0.0",


### PR DESCRIPTION
This includes the changes in https://github.com/pelias/wof-admin-lookup/pull/311 that help with using
the `boundary.country` API parameter with `dependency` placetypes.