### PR TITLE
fix(typo): updating dockerfile to copy and install docker packages in…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV WORKDIR /code/pelias/csv-importer
 WORKDIR ${WORKDIR}
 
 # copy package.json first to prevent npm install being rerun when only code changes
-COPY ./package.json ${WORK}
+COPY ./package.json ${WORKDIR}
 RUN npm install
 
 # copy code into image


### PR DESCRIPTION
…to workdir

As there is no WORK env declared into dockerfile updating package.json copy  make it consistent with dockerfile

:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
<!-- good place to use the magic github words that connect issues with PRs, like 
  - Fixes pelias/pelias#0000
  - Closes pelias/pelias#0000
  - Connected to pelias/pelias#0000
you can also just use good ol' words to explain what this does -->

---
#### Here's what actually got changed :clap:
<!-- try listing some of the things in a nifty checklist
- [x] :cat:
- [ ] :dog:
- [x] :rabbit:
-->

---
#### Here's how others can test the changes :eyes:
<!-- this could be queries or just mentioning that you've written unit/end-to-end tests as part of this awesome work... -->
<!-- did we mention, test are amazing! :rainbow: -->
