### PR TITLE
Remove unused apt dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 # base image
 FROM pelias/baseimage
 
-# downloader apt dependencies
-# note: this is done in one command in order to keep down the size of intermediate containers
-RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
-
 # change working dir
 ENV WORKDIR /code/pelias/csv-importer
 WORKDIR ${WORKDIR}


### PR DESCRIPTION
These packages are now installed in the baseimage, so we don't need to install them here.

See https://github.com/pelias/docker-baseimage/pull/37